### PR TITLE
 Quote the primary key when reversing change URL

### DIFF
--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -5,6 +5,7 @@ from itertools import chain
 
 from django.conf.urls import url
 from django.contrib import messages
+from django.contrib.admin.utils import quote
 from django.db.models.query import QuerySet
 from django.http import Http404, HttpResponseRedirect
 from django.http.response import HttpResponseBase
@@ -264,7 +265,7 @@ class ChangeActionView(SingleObjectMixin, BaseActionView):
 
     @property
     def back_url(self):
-        return reverse(self.back, args=(self.kwargs['pk'],), current_app=self.current_app)
+        return reverse(self.back, args=(quote(self.kwargs['pk']),), current_app=self.current_app)
 
 
 class ChangeListActionView(MultipleObjectMixin, BaseActionView):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='django-object-actions',
-    version='1.0.0',
+    version='1.0.0+frontiersignal.0',
     author='Chris Chang',
     author_email='c@crccheck.com',
     url='https://github.com/crccheck/django-object-actions',


### PR DESCRIPTION
This brings ChangeActionView in line with Django admin's behavior.
Previously it was possible to generate a bad redirect in case of primary
keys that require special quoting behavior.